### PR TITLE
Fix attempted string cast of classes that cannot be cast to string

### DIFF
--- a/src/views/profiler/_config.blade.php
+++ b/src/views/profiler/_config.blade.php
@@ -10,6 +10,8 @@
 				<td>
 					@if (is_array($value))
 						<pre>{{ print_r($value, true) }}</pre>
+					@elseif (is_object($value) && !method_exists($value, '__toString'))
+						{{ get_class($value) }}
 					@else
 						{{ $value }}
 					@endif


### PR DESCRIPTION
I had an issue where closures in my config files were being cast to string.

> [2013-09-30 11:28:41] log.ERROR: exception 'ErrorException' with message 'Object of class Closure could not be converted to string' in ...\app\storage\views\3ac278c0cf4e0defb1e30748a39554a8:14
