### PR TITLE
[BugFix] getMemoryUsage()

### DIFF
--- a/src/Sebklaus/Profiler/Profiler.php
+++ b/src/Sebklaus/Profiler/Profiler.php
@@ -230,7 +230,7 @@ class Profiler {
 	 *
 	 * @return string
 	 */
-	public function getMemoryUsage()
+	public static function getMemoryUsage()
 	{
 		return $this->formatBytes(memory_get_usage());
 	}
@@ -241,7 +241,7 @@ class Profiler {
 	 * @param sting $bytes
 	 * @return string
 	 */
-	protected function formatBytes($bytes)
+	protected static function formatBytes($bytes)
 	{
 		$measures = array('B', 'KB', 'MB', 'GB');
 		$bytes = memory_get_usage();

--- a/src/Sebklaus/Profiler/Profiler.php
+++ b/src/Sebklaus/Profiler/Profiler.php
@@ -244,7 +244,6 @@ class Profiler {
 	protected static function formatBytes($bytes)
 	{
 		$measures = array('B', 'KB', 'MB', 'GB');
-		$bytes = memory_get_usage();
 		for($i = 0; $bytes >= 1024; $i++)
 		{
 			$bytes = $bytes/1024;

--- a/src/Sebklaus/Profiler/Profiler.php
+++ b/src/Sebklaus/Profiler/Profiler.php
@@ -232,7 +232,7 @@ class Profiler {
 	 */
 	public static function getMemoryUsage()
 	{
-		return $this->formatBytes(memory_get_usage());
+		return Profiler::formatBytes(memory_get_usage());
 	}
 
 	/**


### PR DESCRIPTION
Both getMemoryUsage() and formatBytes() need to be static for
getCounts() to return a value for the memory usage.
