### PR TITLE
Updated Routing API usage for Laravel 4.1

### DIFF
--- a/src/Sebklaus/Profiler/Profiler.php
+++ b/src/Sebklaus/Profiler/Profiler.php
@@ -128,7 +128,7 @@ class Profiler {
 		return array(
 			'environment' =>	function(){ return \App::environment(); },
 			'memory' =>			function(){ return Profiler::getMemoryUsage(); },
-			'controller' =>		function(){ return $controller = \Route::currentRouteAction() != "" ? \Route::currentRouteAction() : "N/A"; },
+			'controller' =>		function(){ return $controller = \Route::current()->getActionName() != "" ? \Route::current()->getActionName() : "N/A"; },
 			'routes' =>			function(){ return count(\Route::getRoutes()); },
 			'log' =>			function($app_logs){ return count($app_logs); },
 			'sql' =>			function($sql_log){ return count($sql_log); },

--- a/src/views/profiler/_controller.blade.php
+++ b/src/views/profiler/_controller.blade.php
@@ -5,10 +5,10 @@
 	</tr>
 	<tr>
 		<td>Current route</td>
-		<td>{{ Route::currentRouteName() }}</td>
+		<td>{{ Route::current()->getName() }}</td>
 	</tr>
 	<tr>
 		<td>Current controller action</td>
-		<td>{{ Route::currentRouteAction() }}</td>
+		<td>{{ Route::current()->getActionName() }}</td>
 	</tr>
 </table>

--- a/src/views/profiler/_routes.blade.php
+++ b/src/views/profiler/_routes.blade.php
@@ -18,8 +18,8 @@
             <td>{{ $route->uri() }}</td>
             <td>{{ $name }}</td>
             <td>{{ $route->getActionName() ?: 'Closure' }}</td>
-            <td>{{ implode('|', array_keys($route->getBeforeFilters())) }}</td>
-            <td>{{ implode('|', array_keys($route->getAfterFilters())) }}</td>
+            <td>{{ implode('|', array_keys($route->beforeFilters())) }}</td>
+            <td>{{ implode('|', array_keys($route->afterFilters())) }}</td>
         </tr>
     @endforeach
 </table>

--- a/src/views/profiler/_routes.blade.php
+++ b/src/views/profiler/_routes.blade.php
@@ -9,17 +9,17 @@
     </tr>
     <?php $routes = Route::getRoutes(); ?>
     @foreach($routes as $name => $route)
-        @if ( Route::currentRouteName() == $name)
+        @if ( Route::current()->getName() == $name)
         <tr class="highlight">
         @else
         <tr>
         @endif
-            <td>[{{ array_get($route->getMethods(), 0) }}]</td>
-            <td>{{ $route->getPath() }}</td>
+            <td>[{{ array_get($route->methods(), 0) }}]</td>
+            <td>{{ $route->uri() }}</td>
             <td>{{ $name }}</td>
-            <td>{{ $route->getAction() ?: 'Closure' }}</td>
-            <td>{{ implode('|', $route->getBeforeFilters()) }}</td>
-            <td>{{ implode('|', $route->getAfterFilters()) }}</td>
+            <td>{{ $route->getActionName() ?: 'Closure' }}</td>
+            <td>{{ implode('|', array_keys($route->getBeforeFilters())) }}</td>
+            <td>{{ implode('|', array_keys($route->getAfterFilters())) }}</td>
         </tr>
     @endforeach
 </table>


### PR DESCRIPTION
The Routing API's changed a bit in 4.1. This uses the new API but it's incompatible with 4.0.x. I don't know if you want to maintain a separate branch for 4.0.x after 4.1's been released or have a single file that works for both?
